### PR TITLE
Replace padding with margin to stop images on plot buttons from going out

### DIFF
--- a/jquery.toolbar.css
+++ b/jquery.toolbar.css
@@ -139,7 +139,7 @@
   width: 20px;
   height: 20px;
   text-align: center;
-  padding: 10px;
+  margin: 5px;
   transition: none;
 }
 .tool-item > .fa {


### PR DESCRIPTION
I am not sure where else this is used apart from the plot buttons, but it works for the plot buttons.
